### PR TITLE
feat: move witness to `ress-primitives`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5363,6 +5363,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "ress-primitives"
+version = "0.1.0"
+dependencies = [
+ "alloy-primitives",
+ "serde",
+]
+
+[[package]]
 name = "ress-storage"
 version = "0.1.0"
 dependencies = [
@@ -5370,6 +5378,7 @@ dependencies = [
  "alloy-trie",
  "ress-common",
  "ress-network",
+ "ress-primitives",
  "ress-subprotocol",
  "reth-chainspec",
  "reth-primitives",
@@ -5391,6 +5400,7 @@ dependencies = [
  "alloy-primitives",
  "bincode",
  "futures",
+ "ress-primitives",
  "reth-eth-wire",
  "reth-network",
  "reth-network-api",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,15 +5,28 @@ edition = "2021"
 
 [workspace]
 members = [
-    "crates/subprotocol",
     "bin/ress",
     "bin/reth",
-    "crates/vm",
-    "crates/storage",
-    "crates/network",
     "crates/common",
+    "crates/network",
     "crates/node",
+    "crates/primitives",
+    "crates/storage",
+    "crates/subprotocol",
+    "crates/vm",
 ]
+
+# Explicitly set the resolver to version 2, which is the default for packages with edition >= 2021
+# https://doc.rust-lang.org/edition-guide/rust-2021/default-cargo-resolver.html
+resolver = "2"
+
+[workspace.lints]
+rust.missing_debug_implementations = "warn"
+rust.missing_docs = "warn"
+rust.rust_2018_idioms = { level = "deny", priority = -1 }
+rust.unreachable_pub = "warn"
+rust.unused_must_use = "deny"
+rustdoc.all = "warn"
 
 [workspace.dependencies]
 ress-node = { path = "crates/node" }
@@ -22,6 +35,7 @@ ress-storage = { path = "crates/storage" }
 ress-network = { path = "crates/network" }
 ress-common = { path = "crates/common" }
 ress-vm = { path = "crates/vm" }
+ress-primitives = { path = "crates/primitives" }
 
 clap = { version = "4.4", features = ["derive"] }
 tokio = { version = "1.39", features = ["full"] }

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "ress-primitives"
+rust-version.workspace = true
+version.workspace = true
+edition.workspace = true
+
+[dependencies]
+alloy-primitives.workspace = true
+
+# `serde` feature
+serde = { workspace = true, optional = true }
+
+[features]
+serde = ["dep:serde"]

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod witness;

--- a/crates/primitives/src/witness.rs
+++ b/crates/primitives/src/witness.rs
@@ -1,0 +1,33 @@
+//! Execution witness type.
+
+use alloy_primitives::{BlockNumber, Bytes, B256};
+use std::collections::HashMap;
+
+/// Alias type representing execution state witness.
+/// Execution state witness is a mapping of hashes of encoded
+/// trie nodes to their preimage:
+/// `keccak(rlp(node)): rlp(node)`
+pub type StateWitness = HashMap<B256, Bytes>;
+
+/// Execution witness contains all data necessary to execute the block (except for bytecodes).
+/// That includes:
+///     - state witness - collection of all touched trie nodes which is used for state retrieval and state root computation.
+///     - block hashes - mapping of block number to block hash necessary to execute the [`BLOCKHASH`](https://www.evm.codes/?fork=cancun#40) opcode.
+#[derive(PartialEq, Eq, Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct ExecutionWitness {
+    /// The state witness with touched trie nodes.
+    pub state_witness: StateWitness,
+    /// Mapping of block numbers to block hashes.
+    pub block_hashes: HashMap<BlockNumber, B256>,
+}
+
+impl ExecutionWitness {
+    /// Create new [`ExecutionWitness`].
+    pub fn new(state_witness: StateWitness, block_hashes: HashMap<BlockNumber, B256>) -> Self {
+        Self {
+            state_witness,
+            block_hashes,
+        }
+    }
+}

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -5,6 +5,7 @@ version.workspace = true
 edition.workspace = true
 
 [dependencies]
+ress-primitives.workspace = true
 ress-common.workspace = true
 ress-network.workspace = true
 ress-subprotocol.workspace = true

--- a/crates/storage/src/backends/network.rs
+++ b/crates/storage/src/backends/network.rs
@@ -1,5 +1,6 @@
 use alloy_primitives::B256;
-use ress_subprotocol::{connection::CustomCommand, protocol::proto::StateWitness};
+use ress_primitives::witness::ExecutionWitness;
+use ress_subprotocol::connection::CustomCommand;
 use reth_revm::primitives::Bytecode;
 use tokio::sync::mpsc::UnboundedSender;
 use tracing::info;
@@ -35,7 +36,7 @@ impl NetworkStorage {
     }
 
     /// request to get StateWitness from block hash
-    pub async fn get_witness(&self, block_hash: B256) -> Result<StateWitness, StorageError> {
+    pub async fn get_witness(&self, block_hash: B256) -> Result<ExecutionWitness, StorageError> {
         info!(target:"rlpx-subprotocol", "Request witness");
         let (tx, rx) = tokio::sync::oneshot::channel();
         self.network_peer_conn

--- a/crates/subprotocol/Cargo.toml
+++ b/crates/subprotocol/Cargo.toml
@@ -5,13 +5,21 @@ version.workspace = true
 edition.workspace = true
 
 [dependencies]
-alloy-primitives.workspace = true
+# ress
+ress-primitives = { workspace = true, features = ["serde"] }
+
+# reth
 reth-eth-wire.workspace = true
 reth-network.workspace = true
 reth-network-api.workspace = true
 reth-revm.workspace = true
+
+# alloy
+alloy-primitives.workspace = true
+
+# misc
+futures.workspace = true
 tokio.workspace = true
 tokio-stream.workspace = true
-futures.workspace = true
 serde.workspace = true
 bincode.workspace = true

--- a/crates/subprotocol/src/protocol/proto.rs
+++ b/crates/subprotocol/src/protocol/proto.rs
@@ -3,9 +3,9 @@
 
 use alloy_primitives::{
     bytes::{Buf, BufMut, BytesMut},
-    map::HashMap,
     BlockHash, Bytes, B256,
 };
+use ress_primitives::witness::ExecutionWitness;
 use reth_eth_wire::{protocol::Protocol, Capability};
 use reth_revm::primitives::Bytecode;
 
@@ -35,7 +35,7 @@ pub(crate) enum CustomRlpxProtoMessageKind {
 
     // B. witness
     WitnessReq(BlockHash),
-    WitnessRes(StateWitness),
+    WitnessRes(ExecutionWitness),
 
     // C. bytecode
     BytecodeReq(B256),
@@ -47,10 +47,6 @@ pub enum NodeType {
     Stateful,
     Stateless,
 }
-
-/// hashmap representation of multiple mpt state proof
-/// `keccak(rlp(node)) -> rlp(nod)`
-pub type StateWitness = HashMap<B256, Bytes>;
 
 impl NodeType {
     /// `NodeType` to bytes
@@ -113,7 +109,7 @@ impl CustomRlpxProtoMessage {
     }
 
     /// Response Witness
-    pub fn witness_res(msg: StateWitness) -> Self {
+    pub fn witness_res(msg: ExecutionWitness) -> Self {
         Self {
             message_type: CustomRlpxProtoMessageId::WitnessRes,
             message: CustomRlpxProtoMessageKind::WitnessRes(msg),
@@ -186,7 +182,7 @@ impl CustomRlpxProtoMessage {
                 CustomRlpxProtoMessageKind::WitnessReq(B256::from_slice(&buf[..]))
             }
             CustomRlpxProtoMessageId::WitnessRes => {
-                let deserialize: StateWitness =
+                let deserialize: ExecutionWitness =
                     bincode::deserialize(&buf[..]).expect("Failed to serialize message");
                 CustomRlpxProtoMessageKind::WitnessRes(deserialize)
             }


### PR DESCRIPTION
## Description

Create new `ress-primitives` crate, swap `StateWitness` type alias for new `ExecutionWitness` struct which now also contains block hashes. 