### PR TITLE
feat(net): track requests by id

### DIFF
--- a/crates/net/network/src/launch.rs
+++ b/crates/net/network/src/launch.rs
@@ -1,7 +1,7 @@
 use crate::RessNetworkHandle;
 use ress_common::test_utils::TestPeers;
 use ress_protocol::{
-    NodeType, ProtocolEvent, ProtocolState, RessProtocolCommand, RessProtocolHandler,
+    NodeType, ProtocolEvent, ProtocolState, RessPeerRequest, RessProtocolHandler,
     RessProtocolProvider,
 };
 use reth_chainspec::ChainSpec;
@@ -97,7 +97,7 @@ where
     async fn setup_subprotocol_network(
         mut from_peer: UnboundedReceiver<ProtocolEvent>,
         peer_id: PeerId,
-    ) -> UnboundedSender<RessProtocolCommand> {
+    ) -> UnboundedSender<RessPeerRequest> {
         // Establish connection between peer0 and peer1
         let peer_to_peer = from_peer.recv().await.expect("peer connecting");
         let peer_conn = match peer_to_peer {
@@ -110,21 +110,7 @@ where
                 to_connection
             }
         };
-        info!("🟢 connection established with peer_id: {} ", peer_id);
-
-        // =================================================================
-
-        //  Type message subprotocol
-        let (tx, rx) = tokio::sync::oneshot::channel();
-        peer_conn
-            .send(RessProtocolCommand::NodeType {
-                node_type: NodeType::Stateless,
-                response: tx,
-            })
-            .unwrap();
-        let response = rx.await.unwrap();
-        assert!(response);
-        info!(?response, "🟢 connection type valid");
+        info!(%peer_id, "🟢 connection established");
         peer_conn
     }
 }

--- a/crates/net/protocol/src/connection.rs
+++ b/crates/net/protocol/src/connection.rs
@@ -5,6 +5,7 @@ use alloy_primitives::{bytes::BytesMut, BlockHash, Bytes, B256};
 use futures::{Stream, StreamExt};
 use reth_eth_wire::multiplex::ProtocolConnection;
 use std::{
+    collections::HashMap,
     pin::Pin,
     task::{Context, Poll},
 };
@@ -12,29 +13,22 @@ use tokio::sync::oneshot;
 use tokio_stream::wrappers::UnboundedReceiverStream;
 use tracing::*;
 
-/// Ress protocol command.
+/// Ress peer request.
 #[derive(Debug)]
-pub enum RessProtocolCommand {
-    /// Sends a node type message to the peer
-    NodeType {
-        /// Node type.
-        node_type: NodeType,
-        /// The response will be sent to this channel.
-        response: oneshot::Sender<bool>,
-    },
-    /// Get witness for specific block
-    Witness {
-        /// target block hash that we want to get witness from
-        block_hash: BlockHash,
-        /// The response will be sent to this channel.
-        response: oneshot::Sender<StateWitnessNet>,
-    },
+pub enum RessPeerRequest {
     /// Get bytecode for specific code hash
-    Bytecode {
+    GetBytecode {
         /// Target code hash that we want to get bytecode for.
         code_hash: B256,
-        /// The response will be sent to this channel.
-        response: oneshot::Sender<Bytes>,
+        /// The sender for the response.
+        tx: oneshot::Sender<Bytes>,
+    },
+    /// Get witness for specific block
+    GetWitness {
+        /// target block hash that we want to get witness from
+        block_hash: BlockHash,
+        /// The sender for the response.
+        tx: oneshot::Sender<StateWitnessNet>,
     },
 }
 
@@ -45,16 +39,14 @@ pub struct RessProtocolConnection<P> {
     provider: P,
     /// Node type.
     node_type: NodeType,
-
+    /// Protocol connection.
     conn: ProtocolConnection,
-    commands: UnboundedReceiverStream<RessProtocolCommand>,
-
-    // below two type decides connection type
-    peer_node_type: Option<NodeType>,
-
-    pending_is_valid_connection: Option<oneshot::Sender<bool>>,
-    pending_witness: Option<oneshot::Sender<StateWitnessNet>>,
-    pending_bytecode: Option<oneshot::Sender<Bytes>>,
+    /// Stream of incoming commands.
+    commands: UnboundedReceiverStream<RessPeerRequest>,
+    /// Incremental counter for request ids.
+    next_id: u64,
+    /// Collection of inflight requests.
+    inflight_requests: HashMap<u64, RessPeerRequest>,
 }
 
 impl<P> RessProtocolConnection<P> {
@@ -63,45 +55,37 @@ impl<P> RessProtocolConnection<P> {
         provider: P,
         node_type: NodeType,
         conn: ProtocolConnection,
-        commands: UnboundedReceiverStream<RessProtocolCommand>,
+        commands: UnboundedReceiverStream<RessPeerRequest>,
     ) -> Self {
         Self {
             provider,
             conn,
             commands,
             node_type,
-            peer_node_type: None,
-            pending_is_valid_connection: None,
-            pending_bytecode: None,
-            pending_witness: None,
+            next_id: 0,
+            inflight_requests: HashMap::default(),
         }
     }
 
-    fn on_command(&mut self, command: RessProtocolCommand) -> RessProtocolMessage {
-        match command {
-            RessProtocolCommand::NodeType {
-                node_type,
-                response,
-            } => {
-                self.peer_node_type = Some(node_type);
-                self.pending_is_valid_connection = Some(response);
-                RessProtocolMessage::node_type(node_type)
+    /// Returns the next request id
+    fn next_id(&mut self) -> u64 {
+        let id = self.next_id;
+        self.next_id += 1;
+        id
+    }
+
+    fn on_command(&mut self, command: RessPeerRequest) -> RessProtocolMessage {
+        let next_id = self.next_id();
+        let message = match &command {
+            RessPeerRequest::GetWitness { block_hash, .. } => {
+                RessProtocolMessage::get_witness(next_id, *block_hash)
             }
-            RessProtocolCommand::Witness {
-                block_hash,
-                response,
-            } => {
-                self.pending_witness = Some(response);
-                RessProtocolMessage::get_witness(block_hash)
+            RessPeerRequest::GetBytecode { code_hash, .. } => {
+                RessProtocolMessage::get_bytecode(next_id, *code_hash)
             }
-            RessProtocolCommand::Bytecode {
-                code_hash,
-                response,
-            } => {
-                self.pending_bytecode = Some(response);
-                RessProtocolMessage::get_bytecode(code_hash)
-            }
-        }
+        };
+        self.inflight_requests.insert(next_id, command);
+        message
     }
 }
 
@@ -110,11 +94,11 @@ impl<P: RessProtocolProvider> RessProtocolConnection<P> {
         match self.provider.bytecode(code_hash) {
             Ok(Some(bytecode)) => bytecode,
             Ok(None) => {
-                trace!(target: "ress::net::connection", %code_hash, "bytecode not found");
+                trace!(target: "ress::network::connection", %code_hash, "bytecode not found");
                 Bytes::default()
             }
             Err(error) => {
-                trace!(target: "ress::net::connection", %code_hash, %error, "error retrieving bytecode");
+                trace!(target: "ress::network::connection", %code_hash, %error, "error retrieving bytecode");
                 Bytes::default()
             }
         }
@@ -124,11 +108,11 @@ impl<P: RessProtocolProvider> RessProtocolConnection<P> {
         match self.provider.witness(block_hash) {
             Ok(Some(witness)) => StateWitnessNet::from_iter(witness),
             Ok(None) => {
-                trace!(target: "ress::net::connection", %block_hash, "witness not found");
+                trace!(target: "ress::network::connection", %block_hash, "witness not found");
                 StateWitnessNet::default()
             }
             Err(error) => {
-                trace!(target: "ress::net::connection", %block_hash, %error, "error retrieving witness");
+                trace!(target: "ress::network::connection", %block_hash, %error, "error retrieving witness");
                 StateWitnessNet::default()
             }
         }
@@ -155,39 +139,44 @@ where
                 let msg = RessProtocolMessage::decode_message(&mut &next[..]).unwrap();
 
                 match msg.message {
-                    RessMessageKind::Disconnect => {
-                        // TODO: this actually doesn't disconnecting the channel. How can i gracefully stop
-                        return Poll::Ready(None);
-                    }
                     RessMessageKind::NodeType(node_type) => {
                         if !this.node_type.is_valid_connection(&node_type) {
-                            return Poll::Ready(Some(RessProtocolMessage::disconnect().encoded()));
-                        }
-
-                        if let Some(sender) = this.pending_is_valid_connection.take() {
-                            sender.send(true).ok();
+                            // Terminating the stream disconnects the peer.
+                            return Poll::Ready(None);
                         }
                     }
-                    RessMessageKind::Bytecode(bytes) => {
-                        if let Some(sender) = this.pending_bytecode.take() {
-                            sender.send(bytes).ok();
+                    RessMessageKind::Bytecode(res) => {
+                        if let Some(RessPeerRequest::GetBytecode { tx, .. }) =
+                            this.inflight_requests.remove(&res.request_id)
+                        {
+                            // TODO: validate the bytecode.
+                            let _ = tx.send(res.message);
+                        } else {
+                            // TODO: report bad message
                         }
                     }
-                    RessMessageKind::Witness(msg) => {
-                        if let Some(sender) = this.pending_witness.take() {
-                            sender.send(msg).ok();
+                    RessMessageKind::Witness(res) => {
+                        if let Some(RessPeerRequest::GetWitness { tx, .. }) =
+                            this.inflight_requests.remove(&res.request_id)
+                        {
+                            // TODO: validate the witness.
+                            let _ = tx.send(res.message);
+                        } else {
+                            // TODO: report bad message
                         }
                     }
-                    RessMessageKind::GetBytecode(code_hash) => {
-                        debug!(target: "ress::net::connection", %code_hash, "requesting bytecode");
+                    RessMessageKind::GetBytecode(req) => {
+                        let code_hash = req.message;
+                        debug!(target: "ress::network::connection", %code_hash, "serving bytecode");
                         let bytecode = this.on_bytecode_request(code_hash);
-                        let response = RessProtocolMessage::bytecode(bytecode);
+                        let response = RessProtocolMessage::bytecode(req.request_id, bytecode);
                         return Poll::Ready(Some(response.encoded()));
                     }
-                    RessMessageKind::GetWitness(block_hash) => {
-                        debug!(target: "ress::net::connection", %block_hash, "requesting witness");
+                    RessMessageKind::GetWitness(req) => {
+                        let block_hash = req.message;
+                        debug!(target: "ress::network::connection", %block_hash, "serving witness");
                         let witness = this.on_witness_request(block_hash);
-                        let response = RessProtocolMessage::witness(witness);
+                        let response = RessProtocolMessage::witness(req.request_id, witness);
                         return Poll::Ready(Some(response.encoded()));
                     }
                 };

--- a/crates/net/protocol/src/handlers.rs
+++ b/crates/net/protocol/src/handlers.rs
@@ -1,5 +1,5 @@
 use crate::{
-    connection::{RessProtocolCommand, RessProtocolConnection},
+    connection::{RessPeerRequest, RessProtocolConnection},
     NodeType, RessProtocolMessage, RessProtocolProvider,
 };
 use reth_eth_wire::{
@@ -21,7 +21,7 @@ pub enum ProtocolEvent {
         /// Peer ID.
         peer_id: PeerId,
         /// Sender part for forwarding commands.
-        to_connection: mpsc::UnboundedSender<RessProtocolCommand>,
+        to_connection: mpsc::UnboundedSender<RessPeerRequest>,
     },
 }
 

--- a/crates/net/protocol/src/lib.rs
+++ b/crates/net/protocol/src/lib.rs
@@ -16,4 +16,4 @@ mod handlers;
 pub use handlers::*;
 
 mod connection;
-pub use connection::{RessProtocolCommand, RessProtocolConnection};
+pub use connection::{RessPeerRequest, RessProtocolConnection};

--- a/crates/net/protocol/src/message.rs
+++ b/crates/net/protocol/src/message.rs
@@ -4,26 +4,24 @@ use alloy_primitives::{
     BlockHash, Bytes, B256,
 };
 use alloy_rlp::{BytesMut, Decodable, Encodable};
-use reth_eth_wire::{protocol::Protocol, Capability};
+use reth_eth_wire::{message::RequestPair, protocol::Protocol, Capability};
 
 /// Represents message IDs for `ress` protocol messages.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[repr(u8)]
 pub enum RessMessageType {
-    /// Disconnect message.
-    Disconnect = 0x00,
     /// Node type message.
-    NodeType = 0x01,
-
-    /// Witness request message.
-    GetWitness = 0x02,
-    /// Witness response message.
-    Witness = 0x03,
+    NodeType = 0x00,
 
     /// Bytecode request message.
-    GetBytecode = 0x04,
+    GetBytecode = 0x01,
     /// Bytecode response message.
-    Bytecode = 0x05,
+    Bytecode = 0x02,
+
+    /// Witness request message.
+    GetWitness = 0x03,
+    /// Witness response message.
+    Witness = 0x04,
 }
 
 impl Encodable for RessMessageType {
@@ -39,12 +37,11 @@ impl Encodable for RessMessageType {
 impl Decodable for RessMessageType {
     fn decode(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
         let id = match buf.first().ok_or(alloy_rlp::Error::InputTooShort)? {
-            0x00 => Self::Disconnect,
-            0x01 => Self::NodeType,
-            0x02 => Self::GetWitness,
-            0x03 => Self::Witness,
-            0x04 => Self::GetBytecode,
-            0x05 => Self::Bytecode,
+            0x00 => Self::NodeType,
+            0x01 => Self::GetBytecode,
+            0x02 => Self::Bytecode,
+            0x03 => Self::GetWitness,
+            0x04 => Self::Witness,
             _ => return Err(alloy_rlp::Error::Custom("Invalid message type")),
         };
         buf.advance(1);
@@ -55,27 +52,23 @@ impl Decodable for RessMessageType {
 /// Represents a message in the ress protocol.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum RessMessageKind {
-    /// Represents disconnect message.
-    Disconnect,
-
     /// Represents a node type message required for handshake.
     NodeType(NodeType),
 
     /// Represents a witness request message.
-    GetWitness(BlockHash),
+    GetWitness(RequestPair<BlockHash>),
     /// Represents a witness response message.
-    Witness(StateWitnessNet),
+    Witness(RequestPair<StateWitnessNet>),
 
     /// Represents a bytecode request message.
-    GetBytecode(B256),
+    GetBytecode(RequestPair<B256>),
     /// Represents a bytecode response message.
-    Bytecode(Bytes),
+    Bytecode(RequestPair<Bytes>),
 }
 
 impl Encodable for RessMessageKind {
     fn encode(&self, out: &mut dyn BufMut) {
         match self {
-            Self::Disconnect => (),
             Self::NodeType(node_type) => node_type.encode(out),
             Self::GetWitness(request) => request.encode(out),
             Self::Witness(witness) => witness.encode(out),
@@ -86,7 +79,6 @@ impl Encodable for RessMessageKind {
 
     fn length(&self) -> usize {
         match self {
-            Self::Disconnect => 0,
             Self::NodeType(node_type) => node_type.length(),
             Self::GetWitness(request) => request.length(),
             Self::Witness(witness) => witness.length(),
@@ -113,15 +105,7 @@ impl RessProtocolMessage {
 
     /// Returns the protocol for the `ress` protocol.
     pub fn protocol() -> Protocol {
-        Protocol::new(Self::capability(), 6)
-    }
-
-    /// Disconnect.
-    pub fn disconnect() -> Self {
-        Self {
-            message_type: RessMessageType::Disconnect,
-            message: RessMessageKind::Disconnect,
-        }
+        Protocol::new(Self::capability(), 5)
     }
 
     /// Create node type message.
@@ -132,35 +116,47 @@ impl RessProtocolMessage {
         }
     }
 
-    /// Execution witness request.
-    pub fn get_witness(block_hash: BlockHash) -> Self {
-        Self {
-            message_type: RessMessageType::GetWitness,
-            message: RessMessageKind::GetWitness(block_hash),
-        }
-    }
-
-    /// Execution witness response.
-    pub fn witness(witness: StateWitnessNet) -> Self {
-        Self {
-            message_type: RessMessageType::Witness,
-            message: RessMessageKind::Witness(witness),
-        }
-    }
-
     /// Bytecode request.
-    pub fn get_bytecode(code_hash: B256) -> Self {
+    pub fn get_bytecode(request_id: u64, code_hash: B256) -> Self {
         Self {
             message_type: RessMessageType::GetBytecode,
-            message: RessMessageKind::GetBytecode(code_hash),
+            message: RessMessageKind::GetBytecode(RequestPair {
+                request_id,
+                message: code_hash,
+            }),
         }
     }
 
     /// Bytecode response.
-    pub fn bytecode(bytecode: Bytes) -> Self {
+    pub fn bytecode(request_id: u64, bytecode: Bytes) -> Self {
         Self {
             message_type: RessMessageType::Bytecode,
-            message: RessMessageKind::Bytecode(bytecode),
+            message: RessMessageKind::Bytecode(RequestPair {
+                request_id,
+                message: bytecode,
+            }),
+        }
+    }
+
+    /// Execution witness request.
+    pub fn get_witness(request_id: u64, block_hash: BlockHash) -> Self {
+        Self {
+            message_type: RessMessageType::GetWitness,
+            message: RessMessageKind::GetWitness(RequestPair {
+                request_id,
+                message: block_hash,
+            }),
+        }
+    }
+
+    /// Execution witness response.
+    pub fn witness(request_id: u64, witness: StateWitnessNet) -> Self {
+        Self {
+            message_type: RessMessageType::Witness,
+            message: RessMessageKind::Witness(RequestPair {
+                request_id,
+                message: witness,
+            }),
         }
     }
 
@@ -175,12 +171,11 @@ impl RessProtocolMessage {
     pub fn decode_message(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
         let message_type = RessMessageType::decode(buf)?;
         let message = match message_type {
-            RessMessageType::Disconnect => RessMessageKind::Disconnect,
             RessMessageType::NodeType => RessMessageKind::NodeType(NodeType::decode(buf)?),
-            RessMessageType::GetWitness => RessMessageKind::GetWitness(BlockHash::decode(buf)?),
-            RessMessageType::Witness => RessMessageKind::Witness(StateWitnessNet::decode(buf)?),
-            RessMessageType::GetBytecode => RessMessageKind::GetBytecode(B256::decode(buf)?),
-            RessMessageType::Bytecode => RessMessageKind::Bytecode(Bytes::decode(buf)?),
+            RessMessageType::GetBytecode => RessMessageKind::GetBytecode(RequestPair::decode(buf)?),
+            RessMessageType::Bytecode => RessMessageKind::Bytecode(RequestPair::decode(buf)?),
+            RessMessageType::GetWitness => RessMessageKind::GetWitness(RequestPair::decode(buf)?),
+            RessMessageType::Witness => RessMessageKind::Witness(RequestPair::decode(buf)?),
         };
         Ok(Self {
             message_type,


### PR DESCRIPTION
## Description

Track requests by ID. Avoids accidental overwriting per request type.

Add request IDs to `ress` protocol messages.