### PR TITLE
misc(engine): connect buffered blocks, avoid redundant inserts

### DIFF
--- a/crates/engine/src/download/mod.rs
+++ b/crates/engine/src/download/mod.rs
@@ -52,7 +52,7 @@ impl EngineDownloader {
             return
         }
 
-        trace!(target: "ress::engine::downloader", %block_hash, "Downloading full block");
+        debug!(target: "ress::engine::downloader", %block_hash, "Downloading full block");
         let fut = FetchFullBlockFuture::new(
             self.network.clone(),
             self.consensus.clone(),
@@ -68,7 +68,7 @@ impl EngineDownloader {
             return
         }
 
-        trace!(target: "ress::engine::downloader", %code_hash, "Downloading bytecode");
+        debug!(target: "ress::engine::downloader", %code_hash, "Downloading bytecode");
         let fut = FetchBytecodeFuture::new(self.network.clone(), self.retry_delay, code_hash);
         self.inflight_bytecode_requests.push(fut);
     }
@@ -79,7 +79,7 @@ impl EngineDownloader {
             return
         }
 
-        trace!(target: "ress::engine::downloader", %block_hash, "Downloading witness");
+        debug!(target: "ress::engine::downloader", %block_hash, "Downloading witness");
         let fut = FetchWitnessFuture::new(self.network.clone(), self.retry_delay, block_hash);
         self.inflight_witness_requests.push(fut);
     }
@@ -90,7 +90,7 @@ impl EngineDownloader {
             return
         }
 
-        trace!(target: "ress::engine::downloader", %block_hash, "Downloading finalized");
+        debug!(target: "ress::engine::downloader", %block_hash, "Downloading finalized");
         let fut = FetchFullBlockWithAncestorsFuture::new(
             self.network.clone(),
             self.consensus.clone(),

--- a/crates/engine/src/tree/block_buffer.rs
+++ b/crates/engine/src/tree/block_buffer.rs
@@ -194,7 +194,10 @@ impl<B: Block> BlockBuffer<B> {
     /// This method will only remove the block if it's present inside `self.blocks`.
     /// The block might be missing from other collections, the method will only ensure that it has
     /// been removed.
-    fn remove_block(&mut self, hash: &BlockHash) -> Option<(RecoveredBlock<B>, ExecutionWitness)> {
+    pub fn remove_block(
+        &mut self,
+        hash: &BlockHash,
+    ) -> Option<(RecoveredBlock<B>, ExecutionWitness)> {
         if !self.blocks.contains_key(hash) {
             return None
         }
@@ -271,10 +274,7 @@ impl<B: Block> BlockBuffer<B> {
 
     /// Update missing bytecodes on bytecode received.
     /// Returns block hashes that are ready for insertion.
-    pub fn remove_blocks_with_received_bytecode(
-        &mut self,
-        code_hash: B256,
-    ) -> Vec<(RecoveredBlock<B>, ExecutionWitness)> {
+    pub fn on_bytecode_received(&mut self, code_hash: B256) -> B256HashSet {
         let mut block_hashes = B256HashSet::default();
         self.missing_bytecodes.retain(|block_hash, missing| {
             missing.remove(&code_hash);
@@ -286,9 +286,6 @@ impl<B: Block> BlockBuffer<B> {
             }
         });
         block_hashes
-            .into_iter()
-            .flat_map(|block_hash| self.remove_block_with_children(block_hash))
-            .collect()
     }
 }
 

--- a/crates/engine/src/tree/outcome.rs
+++ b/crates/engine/src/tree/outcome.rs
@@ -32,6 +32,26 @@ pub enum TreeEvent {
 }
 
 impl TreeEvent {
+    /// Create download witness tree event.
+    pub fn download_witness(block_hash: B256) -> Self {
+        Self::Download(DownloadRequest::Witness { block_hash })
+    }
+
+    /// Crate download block tree event.
+    pub fn download_block(block_hash: B256) -> Self {
+        Self::Download(DownloadRequest::Block { block_hash })
+    }
+
+    /// Crate download finalized tree event.
+    pub fn download_finalized(block_hash: B256) -> Self {
+        Self::Download(DownloadRequest::Finalized { block_hash })
+    }
+
+    /// Crate make canonical tree event.
+    pub fn make_canonical(sync_target_head: B256) -> Self {
+        Self::TreeAction(TreeAction::MakeCanonical { sync_target_head })
+    }
+
     /// Return witness download target hash if event is [`DownloadRequest::Witness`] of
     /// [`TreeEvent::Download`] variant.
     pub fn as_witness_download(&self) -> Option<B256> {


### PR DESCRIPTION
## Description

Connect buffered blocks on insert, avoid redundant attempts to insert the blocks. Supersedes #94. 