### PR TITLE
chore: rename message to `GetBlockHeaders` and `BlockHeaders`

### DIFF
--- a/bin/reth/src/main.rs
+++ b/bin/reth/src/main.rs
@@ -208,7 +208,7 @@ where
     N: ProviderNodeTypes<Primitives = EthPrimitives>,
     E: BlockExecutorProvider<Primitives = N::Primitives> + Clone,
 {
-    fn header(&self, block_hash: B256) -> ProviderResult<Option<Header>> {
+    fn block_header(&self, block_hash: B256) -> ProviderResult<Option<Header>> {
         trace!(target: "reth::ress_provider", %block_hash, "Serving header");
         Ok(self.block_by_hash(block_hash)?.map(|b| b.header().clone()))
     }

--- a/crates/net/network/src/handle.rs
+++ b/crates/net/network/src/handle.rs
@@ -1,5 +1,5 @@
 use alloy_primitives::{Bytes, B256};
-use ress_protocol::{GetHeaders, RessPeerRequest, StateWitnessNet};
+use ress_protocol::{GetBlockHeaders, RessPeerRequest, StateWitnessNet};
 use reth_network::NetworkHandle;
 use reth_primitives::{BlockBody, Header};
 use thiserror::Error;
@@ -36,13 +36,13 @@ impl RessNetworkHandle {
 
 impl RessNetworkHandle {
     /// Get block headers.
-    pub async fn fetch_headers(
+    pub async fn fetch_block_headers(
         &self,
-        request: GetHeaders,
+        request: GetBlockHeaders,
     ) -> Result<Vec<Header>, PeerRequestError> {
-        trace!(target: "ress::net", ?request, "requesting header");
+        trace!(target: "ress::net", ?request, "requesting block headers");
         let (tx, rx) = oneshot::channel();
-        self.send_request(RessPeerRequest::GetHeaders { request, tx })?;
+        self.send_request(RessPeerRequest::GetBlockHeaders { request, tx })?;
         let response = rx.await.map_err(|_| PeerRequestError::RequestDropped)?;
         trace!(target: "ress::net", ?request, "headers received");
         Ok(response)

--- a/crates/net/protocol/src/provider.rs
+++ b/crates/net/protocol/src/provider.rs
@@ -1,4 +1,4 @@
-use crate::{GetHeaders, StateWitnessNet};
+use crate::{GetBlockHeaders, StateWitnessNet};
 use alloy_primitives::{Bytes, B256};
 use alloy_rlp::Encodable;
 use reth_primitives::{BlockBody, Header};
@@ -21,14 +21,14 @@ pub const SOFT_RESPONSE_LIMIT: usize = 2 * 1024 * 1024;
 /// A provider trait for ress protocol.
 pub trait RessProtocolProvider: Send + Sync {
     /// Return block header by hash.
-    fn header(&self, block_hash: B256) -> ProviderResult<Option<Header>>;
+    fn block_header(&self, block_hash: B256) -> ProviderResult<Option<Header>>;
 
     /// Return block headers.
-    fn headers(&self, request: GetHeaders) -> ProviderResult<Vec<Header>> {
+    fn block_headers(&self, request: GetBlockHeaders) -> ProviderResult<Vec<Header>> {
         let mut total_bytes = 0;
         let mut block_hash = request.start_hash;
         let mut headers = Vec::new();
-        while let Some(header) = self.header(block_hash)? {
+        while let Some(header) = self.block_header(block_hash)? {
             block_hash = header.parent_hash;
             total_bytes += header.length();
             headers.push(header);

--- a/crates/provider/src/provider.rs
+++ b/crates/provider/src/provider.rs
@@ -106,7 +106,7 @@ impl RessProvider {
 }
 
 impl RessProtocolProvider for RessProvider {
-    fn header(&self, block_hash: B256) -> ProviderResult<Option<Header>> {
+    fn block_header(&self, block_hash: B256) -> ProviderResult<Option<Header>> {
         Ok(self.chain_state.header(&block_hash))
     }
 

--- a/crates/testing/src/rpc_adapter.rs
+++ b/crates/testing/src/rpc_adapter.rs
@@ -7,7 +7,7 @@ use alloy_rpc_types_eth::{Block, BlockId, BlockNumberOrTag, BlockTransactionsKin
 use futures::{stream::FuturesOrdered, StreamExt};
 use parking_lot::RwLock;
 use ress_protocol::{
-    GetHeaders, RessPeerRequest, StateWitnessNet, MAX_BODIES_SERVE, MAX_HEADERS_SERVE,
+    GetBlockHeaders, RessPeerRequest, StateWitnessNet, MAX_BODIES_SERVE, MAX_HEADERS_SERVE,
     SOFT_RESPONSE_LIMIT,
 };
 use reth_primitives::{BlockBody, Header, TransactionSigned};
@@ -53,7 +53,7 @@ impl RpcNetworkAdapter {
         result.ok().flatten()
     }
 
-    async fn on_headers_request(&self, request: GetHeaders) -> Vec<Header> {
+    async fn on_headers_request(&self, request: GetBlockHeaders) -> Vec<Header> {
         let Some(start_block) =
             self.block(request.start_hash.into(), BlockTransactionsKind::Hashes).await
         else {
@@ -127,7 +127,7 @@ impl RpcNetworkAdapter {
     pub async fn run(self, mut request_stream: UnboundedReceiverStream<RessPeerRequest>) {
         while let Some(request) = request_stream.next().await {
             match request {
-                RessPeerRequest::GetHeaders { request, tx } => {
+                RessPeerRequest::GetBlockHeaders { request, tx } => {
                     let provider = self.clone();
                     tokio::spawn(async move {
                         let headers = provider.on_headers_request(request).await;


### PR DESCRIPTION
rename orignal `GetHeaders` and `Headers` message into `GetBlockHeader` and `BlockHeaders` from the motivation from `eth` protocol (https://github.com/ethereum/devp2p/blob/master/caps/eth.md#getblockheaders-0x03)

This should be resolve before #100 docs PR