### PR TITLE
fix: report correct client version and commit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5734,6 +5734,8 @@ dependencies = [
  "tower 0.4.13",
  "tracing",
  "tracing-subscriber",
+ "vergen",
+ "vergen-git2",
 ]
 
 [[package]]

--- a/bin/ress/Cargo.toml
+++ b/bin/ress/Cargo.toml
@@ -70,3 +70,7 @@ tower = "0.4"
 jsonrpsee = "0.24"
 jsonrpsee-server = "0.24"
 async-trait = "0.1.68"
+
+[build-dependencies]
+vergen = { version = "9.0", features = ["build"] }
+vergen-git2 = "1.0"

--- a/bin/ress/build.rs
+++ b/bin/ress/build.rs
@@ -1,0 +1,30 @@
+#![allow(missing_docs)]
+
+use std::{env, error::Error};
+use vergen::{BuildBuilder, CargoBuilder, Emitter};
+use vergen_git2::Git2Builder;
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let mut emitter = Emitter::default();
+
+    let build_builder = BuildBuilder::default().build_timestamp(true).build()?;
+
+    emitter.add_instructions(&build_builder)?;
+
+    let cargo_builder = CargoBuilder::default().features(true).target_triple(true).build()?;
+
+    emitter.add_instructions(&cargo_builder)?;
+
+    let git_builder =
+        Git2Builder::default().describe(false, true, None).dirty(true).sha(false).build()?;
+
+    emitter.add_instructions(&git_builder)?;
+
+    emitter.emit_and_set()?;
+    let sha = env::var("VERGEN_GIT_SHA")?;
+
+    // Set short SHA
+    println!("cargo:rustc-env=VERGEN_GIT_SHA_SHORT={}", &sha[..8]);
+
+    Ok(())
+}

--- a/bin/ress/src/launch.rs
+++ b/bin/ress/src/launch.rs
@@ -38,6 +38,15 @@ use tracing::*;
 
 use crate::{cli::RessArgs, rpc::RessEthRpc};
 
+/// The human readable name of the client
+pub const NAME_CLIENT: &str = "Ress";
+
+/// The latest version from Cargo.toml.
+pub const CARGO_PKG_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+/// The 8 character short SHA of the latest commit.
+pub const VERGEN_GIT_SHA: &str = env!("VERGEN_GIT_SHA_SHORT");
+
 /// Ress node launcher
 #[derive(Debug)]
 pub struct NodeLauncher {
@@ -233,9 +242,9 @@ impl NodeLauncher {
         let (_, payload_builder_handle) = NoopPayloadBuilderService::<EthEngineTypes>::new();
         let client_version = ClientVersionV1 {
             code: ClientCode::RH,
-            name: "Ress".to_string(),
-            version: "".to_string(),
-            commit: "".to_string(),
+            name: NAME_CLIENT.to_string(),
+            version: CARGO_PKG_VERSION.to_string(),
+            commit: VERGEN_GIT_SHA.to_string(),
         };
         let engine_api = EngineApi::new(
             NoopProvider::<ChainSpec, EthPrimitives>::new(self.args.chain.clone()),


### PR DESCRIPTION
Lighthouse is complaining otherwise

```console
Mar 13 21:51:12.001 WARN Execution engine call failed            error: InvalidClientVersion("Input must be exactly 8 characters long (excluding any '0x' prefix)"), service: exec
Mar 13 21:51:12.001 WARN Failed to populate engine version cache, error: ApiError(InvalidClientVersion("Input must be exactly 8 characters long (excluding any '0x' prefix)")), service: beacon
```